### PR TITLE
Change to name loading based on example from ttf_parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,7 +644,7 @@ fn font_name(font: &[u8]) -> Result<String, Error> {
     let name = font
         .names()
         .into_iter()
-        .find(|n| n.name_id == ttf_parser::name_id::FAMILY)
+        .find(|n| n.name_id == ttf_parser::name_id::FULL_NAME && n.is_unicode())
         .ok_or_else(|| Error::BackendError("font does not have a name with the main ID".into()))?;
 
     // TODO: Support macintosh encoding.


### PR DESCRIPTION
Change based on example in a bit of a buried issue on the ttf_parser repo:

https://github.com/RazrFalcon/ttf-parser/issues/85#issuecomment-1019931095

Tested with NERDFonts which were returning a bad family name when trying to load them, changing to FULL_NAME and checking the encoding seems to load the correct name records.

Before change:
```
NAME Name { name: "unsupported encoding", platform_id: Macintosh, encoding_id: 0, language_id: 0, language: English_UnitedStates, name_id: 1 }
```

After change:
```
Name { name: "Monofur Nerd Font", platform_id: Windows, encoding_id: 1, language_id: 1033, language: English_UnitedStates, name_id: 4 }
```

__Edited the initial example as I copied the wrong line__