### PR TITLE
Remove font loading code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,14 @@ version = "0.2.0"
 edition = "2021"
 authors = ["John Nunley <jtnunley01@gmail.com>"]
 description = "A text layout engine for piet based on cosmic-text"
-repository = "https:# github.com/notgull/piet-cosmic-text"
+repository = "https://github.com/notgull/piet-cosmic-text"
 license = "LGPL-3.0-or-later OR MPL-2.0"
-documentation = "https:# docs.rs/piet-cosmic-text"
-homepage = "https:# github.com/notgull/piet-cosmic-text#readme"
+documentation = "https://docs.rs/piet-cosmic-text"
+homepage = "https://github.com/notgull/piet-cosmic-text#readme"
 
 [dependencies]
 cosmic-text = { version = "0.8.0", default-features = false, features = ["std"] }
-ouroboros = { version = "0.15.6", default-features = false }
 piet = { version = "0.6.2", default-features = false }
-ttf-parser = { version = "0.18.1", default-features = false, features = ["glyph-names", "std"] }
 
 [dev-dependencies]
 cosmic-text = { version = "0.8.0", features = ["swash"] }


### PR DESCRIPTION
Once RazrFalcon/fontdb#54 is released and makes its way into `cosmic-text`, we'll be able to handle loading fonts in a reliable way. Until then, it's best to just remove the font handling code for now.

Also removes `ouroboros` because we don't use that anymore.

Related: pop-os/cosmic-text#125